### PR TITLE
Support reading palette arrays as well as palette images

### DIFF
--- a/tools/gxc/src/SpriteManifest.cpp
+++ b/tools/gxc/src/SpriteManifest.cpp
@@ -31,15 +31,17 @@ struct Range
     }
 };
 
-static SpriteManifest::Format parseFormat(const nlohmann::json& jFormat)
+static SpriteManifest::Format parseFormat(const nlohmann::json& jFormat, const bool hasImageFile)
 {
     auto value = jFormat.get<std::string>();
     if (value == "bmp" || value == "raw")
         return SpriteManifest::Format::bmp;
     else if (value == "rle")
         return SpriteManifest::Format::rle;
+    else if (value == "palette" && hasImageFile)
+        return SpriteManifest::Format::paletteImage;
     else if (value == "palette")
-        return SpriteManifest::Format::palette;
+        return SpriteManifest::Format::paletteHex;
     else
         throw std::runtime_error("Unknown format");
 }
@@ -145,21 +147,25 @@ static SpriteManifest::Entry parseEntry(const nlohmann::json& jEntry)
     }
     else
     {
-        result.path = jEntry.at("path").get<std::string>();
+        if (jEntry.contains("path"))
+            result.path = jEntry.at("path").get<std::string>();
         if (jEntry.contains("format"))
-            result.format = parseFormat(jEntry["format"]);
+            result.format = parseFormat(jEntry["format"], jEntry.contains("path"));
         if (jEntry.contains("palette"))
             result.palette = parsePalette(jEntry["palette"]);
+
         if (jEntry.contains("x"))
             result.offsetX = jEntry["x"];
         else if (jEntry.contains("x_offset"))
             result.offsetX = jEntry["x_offset"];
+
         if (jEntry.contains("y"))
             result.offsetY = jEntry["y"];
         else if (jEntry.contains("y_offset"))
             result.offsetY = jEntry["y_offset"];
         else if (jEntry.contains("zoom"))
             result.zoomOffset = jEntry["zoom"];
+
         if (jEntry.contains("srcX"))
             result.srcX = jEntry["srcX"];
         if (jEntry.contains("srcY"))

--- a/tools/gxc/src/SpriteManifest.h
+++ b/tools/gxc/src/SpriteManifest.h
@@ -7,6 +7,15 @@
 
 namespace gxc
 {
+    struct BGRColour
+    {
+        uint8_t blue{};
+        uint8_t green{};
+        uint8_t red{};
+    };
+
+    using ColourVector = std::vector<BGRColour>;
+
     class SpriteArchive;
 
     class SpriteManifest
@@ -33,6 +42,7 @@ namespace gxc
             fs::path path;
             Format format{};
             PaletteKind palette{};
+            ColourVector colours{};
             int32_t offsetX{};
             int32_t offsetY{};
             int32_t zoomOffset{};

--- a/tools/gxc/src/SpriteManifest.h
+++ b/tools/gxc/src/SpriteManifest.h
@@ -17,7 +17,8 @@ namespace gxc
             automatic,
             bmp,
             rle,
-            palette,
+            paletteImage,
+            paletteArray,
             empty
         };
 

--- a/tools/gxc/src/gxc.cpp
+++ b/tools/gxc/src/gxc.cpp
@@ -32,7 +32,7 @@ static void convertPaletteToBmp(const GxEntry& entry, void* dst)
     }
 }
 
-static void encodePalette(Stream& stream, const Image& image)
+static void encodePaletteFromImage(Stream& stream, const Image& image)
 {
     const auto* src = image.pixels.data();
     for (uint32_t x = 0; x < image.width; x++)
@@ -151,10 +151,10 @@ int runBuild(const CommandLineOptions& options)
                 img = img.crop(manifestEntry.srcX, manifestEntry.srcY, manifestEntry.srcWidth, manifestEntry.srcHeight);
             }
 
-            if (manifestEntry.format == SpriteManifest::Format::palette)
+            if (manifestEntry.format == SpriteManifest::Format::paletteImage)
             {
                 MemoryStream ms;
-                encodePalette(ms, img);
+                encodePaletteFromImage(ms, img);
 
                 SpriteArchive::Entry entry;
                 entry.width = img.width;


### PR DESCRIPTION
Ported code from https://github.com/OpenRCT2/OpenRCT2/pull/25844. Ultimately supporting https://github.com/OpenRCT2/OpenRCT2/pull/25681.

(Add `Co-authored-by: Gymnasiast` on merge.)